### PR TITLE
remove-async-on-sync-call 

### DIFF
--- a/lib/ContentTypes.js
+++ b/lib/ContentTypes.js
@@ -36,7 +36,7 @@ class ContentTypes {
       console.log('No Content Types to remove');
     }
   }
-  async removeOutdatedFields(originalContentType, updatedContentType) {
+  removeOutdatedFields(originalContentType, updatedContentType) {
     originalContentType.fields = originalContentType.fields.map(field => {
       const updatedContentTypeFieldIds = updatedContentType.fields.map(f => f.id);
       if (!updatedContentTypeFieldIds.includes(field.id)) {


### PR DESCRIPTION
removeOutdatedFields was declared as async, but was handled as sync code. In this case the promise wasn't needed, so I've removed it. This was causing the next line to attempt to merge the ContentType model into a Promise.

i.e.,
``` ContentTypes.js#56
        const contentTypeWithRemovedFields = this.removeOutdatedFields(foundContentType, contentType);
        const mergedContentType = Object.assign(contentTypeWithRemovedFields, contentType);
        const updatedContentType = await mergedContentType.update();
```
Ultimately this was causing `mergedContentType.update()` to fail 